### PR TITLE
Fix entrypoint.sh creating one folder named {plugins,embedded-db}

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ initialize_data_dir() {
   if [[ ! -d "${OPENFIRE_DATA_DIR}/conf" ]]; then
     sudo -HEu "${OPENFIRE_USER}" cp -a /etc/openfire "${OPENFIRE_DATA_DIR}/conf"
   fi
-  sudo -HEu "${OPENFIRE_USER}" mkdir -p "${OPENFIRE_DATA_DIR}/{plugins,embedded-db}"
+  sudo -HEu "${OPENFIRE_USER}" mkdir -p "${OPENFIRE_DATA_DIR}"/{plugins,embedded-db}
   sudo -HEu "${OPENFIRE_USER}" rm -rf "${OPENFIRE_DATA_DIR}/plugins/admin"
   sudo -HEu "${OPENFIRE_USER}" ln -sf /usr/share/openfire/plugin-admin /var/lib/openfire/plugins/admin
 


### PR DESCRIPTION
New install fails to start because required directories are not being created. 