### PR TITLE
Update makefile to explicit version on build as well as deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build
 
 build:
-	@docker build --tag=gizmotronic/openfire .
+	@docker build --tag=nasqueron/openfire:$(shell cat VERSION) .
 
 release: build
-	@docker build --tag=gizmotronic/openfire:$(shell cat VERSION) .
+	@docker build --tag=nasqueron/openfire:$(shell cat VERSION) .


### PR DESCRIPTION
Not sure what build process you use, but the latest version is never explicitly version tagged. So when this is updated to 4.6, I can't version lock at 4.5.4. I couldn't raise an issue on the repo, so I created a pull request to see if you could just explicitly tag images. Thanks!!!