### PR TITLE
Mock java17-runtime package to avoid issues using APT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,17 @@ ENV OPENFIRE_VERSION=4.8.3 \
     OPENFIRE_DATA_DIR=/var/lib/openfire \
     OPENFIRE_LOG_DIR=/var/log/openfire
 
+COPY fake-java.equivs /tmp/fake-java.equivs
+
 RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo wget fontconfig libfreetype6 \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo equivs wget fontconfig libfreetype6 \
+ && cd /tmp && equivs-build /tmp/fake-java.equivs && dpkg -i /tmp/java17-runtime_17_all.deb \
  && echo "Downloading openfire_${OPENFIRE_VERSION}_all.deb ..." \
  && wget --no-verbose "http://download.igniterealtime.org/openfire/openfire_${OPENFIRE_VERSION}_all.deb" -O /tmp/openfire_${OPENFIRE_VERSION}_all.deb \
- && dpkg -i --force-depends /tmp/openfire_${OPENFIRE_VERSION}_all.deb \
+ && dpkg -i /tmp/openfire_${OPENFIRE_VERSION}_all.deb \
  && mv /var/lib/openfire/plugins/admin /usr/share/openfire/plugin-admin \
  && ln -s /usr/local/openjdk-17/bin/java /usr/bin/java \
- && rm -rf /tmp/openfire_${OPENFIRE_VERSION}_all.deb \
+ && rm -rf /tmp/*.deb /tmp/*.equivs \
  && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /sbin/entrypoint.sh

--- a/fake-java.equivs
+++ b/fake-java.equivs
@@ -1,0 +1,5 @@
+Package: java17-runtime
+Version: 17
+Architecture: all
+Description: dummy java17-runtime package
+ A dummy package to avoid dpkg dependency issues.


### PR DESCRIPTION
Installing Openfire Debian package with `--force-depends` option results in issues using APT next. Trying to install a new package in a container will produce an error warning the user to use `apt --fix-broken install` to resolve the unmet dependencies issue.
To avoid such an issue, build a fake java17-runtime package using `equivs` and install it.

---

When playing with an Openfire container and especially adding some packages to edit manually some files, I stumbled the following error:
```
# apt install vim
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
You might want to run 'apt --fix-broken install' to correct these.
The following packages have unmet dependencies:
 openfire : PreDepends: default-jre-headless (>= 11) but it is not going to be installed or
                        java11-runtime-headless or
                        java11-runtime or
                        java13-runtime-headless or
                        java13-runtime or
                        java16-runtime-headless or
                        java16-runtime or
                        java17-runtime-headless or
                        java17-runtime
 vim : Depends: vim-common (= 2:8.2.2434-3+deb11u1) but it is not going to be installed
       Depends: vim-runtime (= 2:8.2.2434-3+deb11u1) but it is not going to be installed
       Depends: libgpm2 (>= 1.20.7) but it is not going to be installed
E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
```

This PR adds a fake package built with [equivs](https://wiki.debian.org/Packaging/HackingDependencies) to workaround this issue.