### PR TITLE
Use eclipse-temurin:21 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim-bullseye
+FROM eclipse-temurin:21
 
 ENV OPENFIRE_VERSION=4.9.2 \
     OPENFIRE_USER=openfire \
@@ -6,7 +6,7 @@ ENV OPENFIRE_VERSION=4.9.2 \
     OPENFIRE_LOG_DIR=/var/log/openfire
 
 RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo wget fontconfig libfreetype6 \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo wget fontconfig libfreetype6 adduser \
  && echo "Downloading openfire_${OPENFIRE_VERSION}_all.deb ..." \
  && wget --no-verbose "http://download.igniterealtime.org/openfire/openfire_${OPENFIRE_VERSION}_all.deb" -O /tmp/openfire_${OPENFIRE_VERSION}_all.deb \
  && dpkg -i --force-depends /tmp/openfire_${OPENFIRE_VERSION}_all.deb \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,7 +62,7 @@ initialize_log_dir
 
 # default behaviour is to launch openfire
 if [[ -z ${1} ]]; then
-  exec start-stop-daemon --start --chuid "${OPENFIRE_USER}:${OPENFIRE_USER}" --exec /usr/bin/java -- \
+  exec start-stop-daemon --start --chuid "${OPENFIRE_USER}:${OPENFIRE_USER}" --exec ${JAVA_HOME}/bin/java -- \
     -server \
     -Dlog4j.configurationFile="${OPENFIRE_DATA_DIR}/conf/log4j2.xml" \
     -DopenfireHome=/usr/share/openfire \


### PR DESCRIPTION
Replace deprecated openjdk:17-jdk-slim-bullseye base image as now considered as deprecated. The eclipse-temurin:21 is based on Ubuntu 24.04 and the Debian package could still be used just like before.

1. Just add `adduser` to installed packages as needed by the Openfire postinst script.
2. Retrieve Java binary using $JAVA_HOME environment variable.

---

Done some quick tests, setup the server with embedded database, access the admin console and create a test user through XMPP.

Issue describe in PR #6 is still present but it is a first step to upgrade the current Openfire image.
Next step could be to use (very) recent Openfire 4.9.0 release.